### PR TITLE
Add realpath Check to Solve Issue #10

### DIFF
--- a/core/components/filesluggy/elements/plugins/filesluggy.plugin.php
+++ b/core/components/filesluggy/elements/plugins/filesluggy.plugin.php
@@ -44,7 +44,7 @@ switch ($modx->event->name) {
           $basePath = $source->getBasePath();
           $dirName = basename($directory);
           $dirName = $FileSluggy->sanitizeName($dirName,true);
-          $source->renameContainer(str_replace($basePath, '', $directory), $dirName);
+          $source->renameContainer(str_replace(realpath($basePath), '', $directory), $dirName);
         }
       }
       break;


### PR DESCRIPTION
Previously it would get stuck if a relative media source's path started with /, using realpath removes invalid path characters.