### PR TITLE
Help with plugin chaining

### DIFF
--- a/_build/config.json
+++ b/_build/config.json
@@ -74,10 +74,10 @@
             "value": "",
             "area": "fs_type"
        },{
-            "key": "triggerFSOUFEventOnNoRename",
+            "key": "forceFSOUFEvent",
             "type": "combo-boolean",
             "value": "0",
-            "area": "fs_hooks"
+            "area": "fs_events"
        }]
     },
     "database": {},

--- a/_build/config.json
+++ b/_build/config.json
@@ -73,6 +73,11 @@
             "type": "textfield",
             "value": "",
             "area": "fs_type"
+       },{
+            "key": "triggerFSOUFEventOnNoRename",
+            "type": "combo-boolean",
+            "value": "0",
+            "area": "fs_hooks"
        }]
     },
     "database": {},

--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -104,6 +104,15 @@ $settings['filesluggy.constrain_mediasource']->fromArray(array(
     'area' => 'fs_type',
 ),'',true,true);
 
+$settings['filesluggy.triggerFSOUFEventOnNoRename']= $modx->newObject('modSystemSetting');
+$settings['filesluggy.triggerFSOUFEventOnNoRename']->fromArray(array(
+    'key' => 'filesluggy.triggerFSOUFEventOnNoRename',
+    'value' => false,
+    'xtype' => 'combo-boolean',
+    'namespace' => 'filesluggy',
+    'area' => 'fs_hooks',
+),'',true,true);
+
 
 
 return $settings;

--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -104,13 +104,13 @@ $settings['filesluggy.constrain_mediasource']->fromArray(array(
     'area' => 'fs_type',
 ),'',true,true);
 
-$settings['filesluggy.triggerFSOUFEventOnNoRename']= $modx->newObject('modSystemSetting');
-$settings['filesluggy.triggerFSOUFEventOnNoRename']->fromArray(array(
-    'key' => 'filesluggy.triggerFSOUFEventOnNoRename',
+$settings['filesluggy.forceFSOUFEvent']= $modx->newObject('modSystemSetting');
+$settings['filesluggy.forceFSOUFEvent']->fromArray(array(
+    'key' => 'filesluggy.forceFSOUFEvent',
     'value' => false,
     'xtype' => 'combo-boolean',
     'namespace' => 'filesluggy',
-    'area' => 'fs_hooks',
+    'area' => 'fs_events',
 ),'',true,true);
 
 

--- a/core/components/filesluggy/elements/plugins/filesluggy.plugin.php
+++ b/core/components/filesluggy/elements/plugins/filesluggy.plugin.php
@@ -69,13 +69,27 @@ switch ($modx->event->name) {
                             if ($FileSluggy->checkFileNameChanged()) {
                                 $newFileName = $FileSluggy->checkFileExists($basePath . $directory . $newFileName);
                                 if ($source->renameObject($oldPath, $newFileName)) {
+                                    $newFiles = $files;
+                                    $newFiles['file']['name'] = $newFileName;
                                     $modx->invokeEvent('FileSluggyOnUpdateFilename', array(
                                         'oldName' => $file['name'],
-                                        'newName' => $newFileName
+                                        'newName' => $newFileName,
+                                        'files' => $newFiles,
+                                        'source' => $source,
+                                        'directory' => $directory
                                     ));
                                     return;
                                 } else {
-                                    return;
+                                  if($modx->getOption('filesluggy.triggerFSOUFEventOnNoRename')) {
+                                    $modx->invokeEvent('FileSluggyOnUpdateFilename', array(
+                                        'oldName' => $file['name'],
+                                        'newName' => $newFileName,
+                                        'files' => $newFiles,
+                                        'source' => $source,
+                                        'directory' => $directory
+                                    ));
+                                  }
+                                  return;
                                 }
                             } else {
                                 return;

--- a/core/components/filesluggy/elements/plugins/filesluggy.plugin.php
+++ b/core/components/filesluggy/elements/plugins/filesluggy.plugin.php
@@ -80,19 +80,19 @@ switch ($modx->event->name) {
                                     ));
                                     return;
                                 } else {
-                                  if($modx->getOption('filesluggy.triggerFSOUFEventOnNoRename')) {
-                                    $modx->invokeEvent('FileSluggyOnUpdateFilename', array(
-                                        'oldName' => $file['name'],
-                                        'newName' => $newFileName,
-                                        'files' => $newFiles,
-                                        'source' => $source,
-                                        'directory' => $directory
-                                    ));
-                                  }
                                   return;
                                 }
                             } else {
-                                return;
+                              if($modx->getOption('filesluggy.forceFSOUFEvent')) {
+                                $modx->invokeEvent('FileSluggyOnUpdateFilename', array(
+                                  'oldName' => $file['name'],
+                                  'newName' => $newFileName,
+                                  'files' => $files,
+                                  'source' => $source,
+                                  'directory' => $directory
+                                ));
+                              }
+                              return;
                             }
                         } else {
                             return;

--- a/core/components/filesluggy/lexicon/en/default.inc.php
+++ b/core/components/filesluggy/lexicon/en/default.inc.php
@@ -28,7 +28,10 @@ $_lang['setting_filesluggy.constrain_mediasource'] = 'Constrain to MediaSource';
 $_lang['setting_filesluggy.constrain_mediasource_desc'] = 'To which mediasource you would like to constrain FileSluggy. Leave empty to allow on all.  Enter the ID\'s of the media sources Comma separated value';
 $_lang['setting_filesluggy.sanitizeDir'] = 'Sanitize directories';
 $_lang['setting_filesluggy.sanitizeDir_desc'] = 'When enabled, FileSluggy also sanitizes directories when created or renamed.';
+$_lang['setting_filesluggy.triggerFSOUFEventOnNoRename'] = 'Force FileSluggyOnUpdateFile event';
+$_lang['setting_filesluggy.triggerFSOUFEventOnNoRename_desc'] = 'Force the FileSluggyOnUpdateFile event to trigger even if a file rename wasn\'t required';
 
 $_lang['area_fs_encoding'] = 'Transliteration Settings';
 $_lang['area_fs_guid'] = 'Output settings';
 $_lang['area_fs_type'] = 'File types';
+$_lang['area_fs_events'] = 'Events';

--- a/core/components/filesluggy/lexicon/en/default.inc.php
+++ b/core/components/filesluggy/lexicon/en/default.inc.php
@@ -28,8 +28,8 @@ $_lang['setting_filesluggy.constrain_mediasource'] = 'Constrain to MediaSource';
 $_lang['setting_filesluggy.constrain_mediasource_desc'] = 'To which mediasource you would like to constrain FileSluggy. Leave empty to allow on all.  Enter the ID\'s of the media sources Comma separated value';
 $_lang['setting_filesluggy.sanitizeDir'] = 'Sanitize directories';
 $_lang['setting_filesluggy.sanitizeDir_desc'] = 'When enabled, FileSluggy also sanitizes directories when created or renamed.';
-$_lang['setting_filesluggy.triggerFSOUFEventOnNoRename'] = 'Force FileSluggyOnUpdateFile event';
-$_lang['setting_filesluggy.triggerFSOUFEventOnNoRename_desc'] = 'Force the FileSluggyOnUpdateFile event to trigger even if a file rename wasn\'t required';
+$_lang['setting_filesluggy.forceFSOUFEvent'] = 'Force FileSluggyOnUpdateFile event';
+$_lang['setting_filesluggy.forceFSOUFEvent_desc'] = 'Force the FileSluggyOnUpdateFile event to trigger even if a file rename wasn\'t required';
 
 $_lang['area_fs_encoding'] = 'Transliteration Settings';
 $_lang['area_fs_guid'] = 'Output settings';


### PR DESCRIPTION
At present, it's difficult to do anything with the result of a FileSluggy rename. Only the old and new file names are passed to the FileSluggyOnUpdateFileName event whereas to have something work on the files, it'll also want the media source, upload directory and the other details stored in the $files variable.

This update adds those to the event trigger as well as adding a system-setting to allow the user to force the FileSluggyOnUpdateFileName event to be triggered with the original file upload information in the event that a rename wasn't actually required.

Doing it this way allows plugins to 'hitch their wagon' to the event REGARDLESS of whether a file rename took place. The alternative would be to trigger on both the FileSluggyOnUpdateFileName event AS WELL AS the OnFileManagerUpload event, knowing that one or the other was going to find its target file missing and be the wrong code to run.

Would require insertion of new 'nl' lexicon items - I've only added the English as it's all I know.